### PR TITLE
smdk4412: kill low latency audio

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -140,7 +140,6 @@ PRODUCT_PACKAGES += \
 
 # These are the hardware-specific features
 PRODUCT_COPY_FILES += \
-    frameworks/native/data/etc/android.hardware.audio.low_latency.xml:system/etc/permissions/android.hardware.audio.low_latency.xml \
     frameworks/native/data/etc/android.hardware.bluetooth_le.xml:system/etc/permissions/android.hardware.bluetooth_le.xml \
     frameworks/native/data/etc/android.hardware.camera.autofocus.xml:system/etc/permissions/android.hardware.camera.autofocus.xml \
     frameworks/native/data/etc/android.hardware.camera.flash-autofocus.xml:system/etc/permissions/android.hardware.camera.flash-autofocus.xml \


### PR DESCRIPTION
a2dp is super stuttery with low-latency audio enabled

Change-Id: Ib3a6a0d666635f01ab51a21074322b61bd148219