### PR TITLE
smdk4412-common: camera: remove unsupported preview sizes

### DIFF
--- a/camera/exynos_camera.c
+++ b/camera/exynos_camera.c
@@ -55,7 +55,6 @@ struct exynos_camera_mbus_resolution exynos_camera_mbus_resolutions_s5k6a3_smdk4
 	{ 320, 240,	1392, 1044 },
 	// 1:1 ratio
 	{ 1392, 1392,	1392, 1392 },
-	{ 704, 704,	1392, 1392 },
 	{ 320, 320,	1392, 1392 },
 };
 
@@ -86,7 +85,7 @@ struct exynos_camera_preset exynos_camera_presets_smdk4x12[] = {
 		.vertical_view_angle = 49.3f,
 		.metering = METERING_CENTER,
 		.params = {
-			.preview_size_values = "960x720,1280x720,1184x666,960x640,704x576,640x480,352x288,320x240",
+			.preview_size_values = "960x720,1280x720,880x720,640x480,352x288,320x240",
 			.preview_size = "960x720",
 			.preview_format_values = "yuv420sp,yuv420p,rgb565",
 			.preview_format = "yuv420sp",
@@ -179,7 +178,7 @@ struct exynos_camera_preset exynos_camera_presets_smdk4x12[] = {
 		.vertical_view_angle = 52.58f,
 		.metering = METERING_CENTER,
 		.params = {
-			.preview_size_values = "1280x720,960x720,640x480,320x240,704x704,320x320",
+			.preview_size_values = "1280x720,960x720,640x480,320x240,320x320",
 			.preview_size = "960x720",
 			.preview_format_values = "yuv420sp,yuv420p,rgb565",
 			.preview_format = "yuv420sp",
@@ -248,7 +247,7 @@ struct exynos_camera_preset exynos_camera_presets_smdk4x12[] = {
 			.image_stabilization_values = "off",
 		},
 		.mbus_resolutions = (struct exynos_camera_mbus_resolution *) &exynos_camera_mbus_resolutions_s5k6a3_smdk4x12,
-		.mbus_resolutions_count = 8,
+		.mbus_resolutions_count = 7,
 	},
 };
 


### PR DESCRIPTION
These unsupported preview sizes cause the preview to appear messed up.
Remove them to make sure no application ends up using them.

Change-Id: Ie5dded5e3ea88611347291f52ae1f70966aaa40b